### PR TITLE
fix: refactor only when `DB::raw` is inside of a `*Raw` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,17 @@ vendor/bin/rector process --clear-cache
 ### Before
 
 ```php
-DB::select(DB::raw('select 1'));
+$orders = DB::table('orders')
+    ->selectRaw(DB::raw('price * ? as price_with_tax'), [1.0825])
+    ->get();
 ```
 
 ### After
 
 ```php
-DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));
+$orders = DB::table('orders')
+    ->selectRaw(DB::raw('price * ? as price_with_tax')->getValue(DB::getQueryGrammar()), [1.0825])
+    ->get();
 ```
 
 ## License

--- a/src/LaravelDatabaseExpressionsRector.php
+++ b/src/LaravelDatabaseExpressionsRector.php
@@ -21,8 +21,8 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
         return new RuleDefinition(
             'Fix Laravel 10 database expressions', [
                 new CodeSample(
-                    "DB::select(DB::raw('select 1'));",
-                    "DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));"
+                    "DB::table('orders')->selectRaw(DB::raw('price * ? as price_with_tax'), [1.0825])->get();",
+                    "DB::table('orders')->selectRaw('price * ? as price_with_tax', [1.0825])->get();",
                 )
             ]
         );
@@ -42,13 +42,16 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
     public function refactor(Node $node): ?Node
     {
         /** @var Node */
-        $subNode = $node->args[0]->value ?? null;
+        $childNode = $node->args[0]->value ?? null;
+
+        $className = $this->getName($node->name);
+        $childClassName = isset($childNode->class) ? $this->getName($childNode->class) : '';
+        $childMethodName = isset($childNode->name) ? $this->getName($childNode->name) : '';
 
         if (
-            ! isset($subNode->class) ||
-            $this->getName($node->name) !== 'select' ||
-            strpos($this->getName($subNode->class), 'DB') === false ||
-            $this->getName($subNode->name) !== 'raw'
+            ! str_ends_with($className, 'Raw') ||
+            ! str_ends_with($childClassName, 'DB') ||
+            $childMethodName !== 'raw'
         ) {
             return null;
         }
@@ -61,7 +64,7 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
         );
 
         $node->args[0]->value = new MethodCall(
-            $subNode,
+            $childNode,
             new Identifier('getValue'),
             $arguments
         );

--- a/src/LaravelDatabaseExpressionsRector.php
+++ b/src/LaravelDatabaseExpressionsRector.php
@@ -19,11 +19,12 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
-            'Fix Laravel 10 database expressions', [
+            'Fix Laravel 10 database expressions',
+            [
                 new CodeSample(
                     "DB::table('orders')->selectRaw(DB::raw('price * ? as price_with_tax'), [1.0825])->get();",
                     "DB::table('orders')->selectRaw('price * ? as price_with_tax', [1.0825])->get();",
-                )
+                ),
             ]
         );
     }
@@ -49,16 +50,16 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
         $childMethodName = isset($childNode->name) ? $this->getName($childNode->name) : '';
 
         if (
-            ! str_ends_with($className, 'Raw') ||
-            ! str_ends_with($childClassName, 'DB') ||
-            $childMethodName !== 'raw'
+            !str_ends_with($className, 'Raw')
+            || !str_ends_with($childClassName, 'DB')
+            || 'raw' !== $childMethodName
         ) {
             return null;
         }
 
         $arguments[] = new Arg(
             new StaticCall(
-            new Name('DB'),
+                new Name('DB'),
                 'getQueryGrammar'
             )
         );

--- a/tests/ExampleRectorTest.php
+++ b/tests/ExampleRectorTest.php
@@ -4,27 +4,31 @@ declare(strict_types=1);
 
 namespace Remarkablemark\Tests\RectorExample;
 
-use Iterator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 final class ExampleRectorTest extends AbstractRectorTestCase
 {
     /**
-     * @dataProvider provideData
+     * @dataProvider provideCases
      */
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
     }
 
-    public static function provideData(): Iterator
+    public static function provideCases(): iterable
     {
-        return self::yieldFilesFromDirectory(__DIR__ . '/fixture');
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
     public function provideConfigFilePath(): string
     {
-        return __DIR__ . '/config/rector-config.php';
+        return __DIR__.'/config/rector-config.php';
     }
 }

--- a/tests/fixture/SkipRuleTestFixture.php.inc
+++ b/tests/fixture/SkipRuleTestFixture.php.inc
@@ -18,3 +18,17 @@ function select5() {
     DB::select('select 5');
     $db->select('select 5');
 }
+
+DB::select(DB::raw('select 6'));
+
+DB::select(
+    DB::raw('select 7')
+);
+
+$db->select(DB::raw('select 8'));
+
+$orders = DB::table('orders')
+    ->select('department', DB::raw('SUM(price) as total_sales'))
+    ->groupBy('department')
+    ->havingRaw('SUM(price) > ?', [2500])
+    ->get();

--- a/tests/fixture/TestFixture.php.inc
+++ b/tests/fixture/TestFixture.php.inc
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
 
-DB::select(DB::raw('select 1'));
+$orders = DB::table('orders')
+    ->selectRaw(DB::raw('price * ? as price_with_tax'), [1.0825])
+    ->get();
 
-DB::select(
-    DB::raw('select 2')
-);
-
-$db->select(DB::raw('select 3'));
+$orders = DB::table('orders')
+    ->whereRaw(DB::raw('price > IF(state = "TX", ?, 100)'), [200])
+    ->get();
 -----
 <?php
 
@@ -18,10 +18,10 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
 
-DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));
+$orders = DB::table('orders')
+    ->selectRaw(DB::raw('price * ? as price_with_tax')->getValue(DB::getQueryGrammar()), [1.0825])
+    ->get();
 
-DB::select(
-    DB::raw('select 2')->getValue(DB::getQueryGrammar())
-);
-
-$db->select(DB::raw('select 3')->getValue(DB::getQueryGrammar()));
+$orders = DB::table('orders')
+    ->whereRaw(DB::raw('price > IF(state = "TX", ?, 100)')->getValue(DB::getQueryGrammar()), [200])
+    ->get();


### PR DESCRIPTION
## What is the motivation for this pull request?

fix: refactor only when `DB::raw` is inside of a `*Raw` method

https://laravel.com/docs/10.x/queries#raw-expressions

## What is the current behavior?

Rector refactors `DB::select(DB::raw(...))`

## What is the new behavior?

Rector refactors `DB::table(..)->selectRaw(DB::raw(...))->get()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation