### PR TITLE
fix: revert `DB::raw` inside `DB::select` regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,13 @@ vendor/bin/rector process --clear-cache
 ### Before
 
 ```php
-$orders = DB::table('orders')
-    ->selectRaw(DB::raw('price * ? as price_with_tax'), [1.0825])
-    ->get();
+DB::select(DB::raw('select 1'));
 ```
 
 ### After
 
 ```php
-$orders = DB::table('orders')
-    ->selectRaw(DB::raw('price * ? as price_with_tax')->getValue(DB::getQueryGrammar()), [1.0825])
-    ->get();
+DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));
 ```
 
 ## License

--- a/src/LaravelDatabaseExpressionsRector.php
+++ b/src/LaravelDatabaseExpressionsRector.php
@@ -22,8 +22,8 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
             'Fix Laravel 10 database expressions',
             [
                 new CodeSample(
-                    "DB::table('orders')->selectRaw(DB::raw('price * ? as price_with_tax'), [1.0825])->get();",
-                    "DB::table('orders')->selectRaw('price * ? as price_with_tax', [1.0825])->get();",
+                    "DB::select(DB::raw('select 1'));",
+                    "DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));"
                 ),
             ]
         );
@@ -45,14 +45,17 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
         /** @var Node */
         $childNode = $node->args[0]->value ?? null;
 
-        $className = $this->getName($node->name);
+        $methodName = $this->getName($node->name);
         $childClassName = isset($childNode->class) ? $this->getName($childNode->class) : '';
         $childMethodName = isset($childNode->name) ? $this->getName($childNode->name) : '';
 
         if (
-            !str_ends_with($className, 'Raw')
-            || !str_ends_with($childClassName, 'DB')
-            || 'raw' !== $childMethodName
+            // skip `DB::table()->select()`
+            ($node instanceof MethodCall && $methodName === 'select')
+            // match `DB::select()` or `Model::selectRaw()`
+            || !($methodName === 'select' || str_ends_with($methodName, 'Raw'))
+            // match `DB::raw()`
+            || !str_ends_with($childClassName, 'DB') || 'raw' !== $childMethodName
         ) {
             return null;
         }

--- a/src/LaravelDatabaseExpressionsRector.php
+++ b/src/LaravelDatabaseExpressionsRector.php
@@ -51,9 +51,9 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
 
         if (
             // skip `DB::table()->select()`
-            ($node instanceof MethodCall && $methodName === 'select')
+            ($node instanceof MethodCall && 'select' === $methodName)
             // match `DB::select()` or `Model::selectRaw()`
-            || !($methodName === 'select' || str_ends_with($methodName, 'Raw'))
+            || !('select' === $methodName || str_ends_with($methodName, 'Raw'))
             // match `DB::raw()`
             || !str_ends_with($childClassName, 'DB') || 'raw' !== $childMethodName
         ) {

--- a/tests/fixture/TestFixture.php.inc
+++ b/tests/fixture/TestFixture.php.inc
@@ -24,10 +24,10 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
 
-DB::select(DB::raw('select 1'));
+DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));
 
 DB::select(
-    DB::raw('select 2')
+    DB::raw('select 2')->getValue(DB::getQueryGrammar())
 );
 
 $orders = DB::table('orders')


### PR DESCRIPTION
## What is the motivation for this pull request?

Revert regression caused by #5

## What is the current behavior?

`DB::select(DB::raw(...))` is not refactored

## What is the new behavior?

`DB::select(DB::raw(...))` is refactored

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation