### PR TITLE
feat: replace `DB::raw()` with first argument string

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ DB::select(DB::raw('select 1'));
 ### After
 
 ```php
-DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));
+DB::select('select 1');
 ```
 
 ## License

--- a/src/LaravelDatabaseExpressionsRector.php
+++ b/src/LaravelDatabaseExpressionsRector.php
@@ -5,11 +5,8 @@ declare(strict_types=1);
 namespace Remarkablemark\RectorLaravelDatabaseExpressions;
 
 use PhpParser\Node;
-use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;

--- a/src/LaravelDatabaseExpressionsRector.php
+++ b/src/LaravelDatabaseExpressionsRector.php
@@ -23,7 +23,7 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
             [
                 new CodeSample(
                     "DB::select(DB::raw('select 1'));",
-                    "DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));"
+                    "DB::select('select 1');"
                 ),
             ]
         );
@@ -60,18 +60,7 @@ final class LaravelDatabaseExpressionsRector extends AbstractRector
             return null;
         }
 
-        $arguments[] = new Arg(
-            new StaticCall(
-                new Name('DB'),
-                'getQueryGrammar'
-            )
-        );
-
-        $node->args[0]->value = new MethodCall(
-            $childNode,
-            new Identifier('getValue'),
-            $arguments
-        );
+        $node->args[0]->value = $childNode->args[0]->value;
 
         return $node;
     }

--- a/tests/fixture/TestFixture.php.inc
+++ b/tests/fixture/TestFixture.php.inc
@@ -24,16 +24,16 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\DB;
 
-DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));
+DB::select('select 1');
 
 DB::select(
-    DB::raw('select 2')->getValue(DB::getQueryGrammar())
+    'select 2'
 );
 
 $orders = DB::table('orders')
-    ->selectRaw(DB::raw('price * ? as price_with_tax')->getValue(DB::getQueryGrammar()), [1.0825])
+    ->selectRaw('price * ? as price_with_tax', [1.0825])
     ->get();
 
 $orders = DB::table('orders')
-    ->whereRaw(DB::raw('price > IF(state = "TX", ?, 100)')->getValue(DB::getQueryGrammar()), [200])
+    ->whereRaw('price > IF(state = "TX", ?, 100)', [200])
     ->get();


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: replace `DB::raw()` with first argument string

## What is the current behavior?

```diff
-DB::select(DB::raw('select 1'));
+DB::select(DB::raw('select 1')->getValue(DB::getQueryGrammar()));
```

## What is the new behavior?


```diff
-DB::select(DB::raw('select 1'));
+DB::select('select 1');
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation